### PR TITLE
Fix requestPairingCode to work without QR scan first

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -193,23 +193,8 @@ class Client extends EventEmitter {
             
             console.log(`Requesting pairing code for: ${formattedNumber}`);
             
-            // Wait for the connection to be fully established
-            if (!this.socket.user) {
-                console.log('Waiting for QR code scan first before requesting pairing code...');
-                
-                // If we need a pairing code for a real phone, we should inform the user
-                // that they may need to scan a QR code first to establish the connection
-                this.emit('error', new Error('Please scan the QR code first to establish the connection, then request the pairing code'));
-                
-                // For real implementations, WhatsApp may require scanning a QR code once
-                // before allowing pairing codes, so we should handle this gracefully
-                
-                // In this case, we'll return a demo code for testing, but in reality,
-                // the correct implementation would be to wait for QR scan first
-                const fallbackCode = '12345678';
-                this.emit('pairing_code', `DEMO (scan QR first): ${fallbackCode}`);
-                return fallbackCode;
-            }
+            // The function should work even without socket.user being established
+            // Baileys can handle the pairing code request without pre-authentication
             
             // Request pairing code using baileys
             const pairingResult = await this.socket.requestPairingCode(formattedNumber);


### PR DESCRIPTION
Această modificare repară funcția requestPairingCode pentru a permite obținerea codurilor de asociere fără să necesite scanarea prealabilă a unui cod QR.

## Problema
Actuala implementare verifică dacă `this.socket.user` există, și dacă nu, returnează un cod demo `12345678`, împiedicând obținerea unui cod real.

## Soluția
Am eliminat verificarea `this.socket.user` și codul care returnează un cod demo, deoarece biblioteca Baileys poate obține un cod de asociere fără autentificare prealabilă.

Această modificare permite utilizatorilor să folosească metoda de autentificare cu cod de asociere fără să fie nevoiți să scaneze întâi un cod QR.